### PR TITLE
docs: updated grammar error corrector

### DIFF
--- a/grammar-error-corrector/config.py
+++ b/grammar-error-corrector/config.py
@@ -1,10 +1,7 @@
 import os
 import logging
-from pathlib import Path
 from dataclasses import dataclass
 import datetime
-# Basic
-# PROJECT_NAME = "gantry-demo-data-backfill"
 
 @dataclass
 class GantryConfig:

--- a/grammar-error-corrector/data_curation.ipynb
+++ b/grammar-error-corrector/data_curation.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -13,7 +12,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from config import GantryConfig, DataStorageConfig\n",
@@ -25,7 +26,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "gantry.init(api_key=GantryConfig.GANTRY_API_KEY)\n",
@@ -58,12 +61,21 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "attachments": {},
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "dataset = new_accounts_curator.get_curated_dataset()"
+    "A few things to note here:\n",
+    "- We provide the application name to tie this curator to the associated application\n",
+    "- We use `GantryConfig` and `DataStorageConfig` to grab some configurations, like the earliest timestamp of the data which will trigger Gantry to backfill all of the intervals between that date and now\n",
+    "- We use the `BoundedRangeCurator` because it makes it easy to specify a curator according the bounds on a field, namely `account_age_days`\n",
+    "- We choose the, somewhat arbitrary, limit of 1000 records to represent our daily labeling budget\n",
+    "\n",
+    "This curator tells Gantry how to marshall your data into versions in a **dataset**.\n",
+    "\n",
+    "The following code will do two things for us:\n",
+    "1. Grab the dataset that our curator populating.\n",
+    "2. List the versions in the dataset. Each version represents a historical interval (in this case day) of data. Listing the versions makes the relationship between curators and datasets explicit: as curator jobs run, one for each interval, they create versions of a dataset. The versions contain metadata about what fraction of the specified limit is being met, as you can see below in the format: `x records added from interval of size y`"
    ]
   },
   {
@@ -72,7 +84,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "dataset = new_accounts_curator.get_curated_dataset()\n",
     "dataset.list_versions()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have seen how curators can make it easy to tell Gantry what data you want to gather, and let Gantry take care of gathering it, let's dive into datasets.\n",
+    "\n",
+    "### Datasets\n",
+    "Gantry datasets are a lightweight container for your data with simple versioning semantics that aim to make it straightforward to build more robust ML pipelines. Versioning is at the file level, and centers on two operations: `push` and `pull`. Curators `push` data to Gantry Datasets. Users `pull` data from them to analyze, label, or train on. Users can also make local modifications to datasets, and `push` them back. All `push` operations create a new version, and each version is written to underlying S3 storage. You can read about datasets in more detail in the [Datasets guide](https://docs.gantry.io/docs/datasets).\n",
+    "\n",
+    "Let's pull the latest version of the dataset from our curator:"
    ]
   },
   {
@@ -82,6 +108,14 @@
    "outputs": [],
    "source": [
     "dataset.pull()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Gantry datasets can be loaded them directly into HuggingFace Datasets, which can in turn be turned into Pandas DataFrame objects. All the type mappings are handled by the integration:"
    ]
   },
   {
@@ -102,11 +136,19 @@
    "source": [
     "df"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now analyze, train on, or label this dataset. If we want to do manual data manipulation, we can modify it and push a new version back to Gantry."
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -120,9 +162,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.10"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "a3df6fd0f7e696005f34938b19f6cb395601341b0ef69ce9e9b6aaa77428e11a"
@@ -130,5 +171,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
A typical tutorial workflow would be to open this notebook and then start executing cells. It's an annoying experience to go back and forth between this notebook and the website. All the information contained in this section of the tutorial has been copied directly into this notebook. The website has also been updated with a more streamlined workflow for the user: https://docs.gantry.io/docs/quickstart